### PR TITLE
ci: workaround for failing Cypress tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
           node-version: 18
       - run: npm install
         working-directory: frontend
+      - run: npm install -D https://cdn.cypress.io/beta/npm/12.8.2/linux-x64/retry-dynamic-imports-ed984ef8e1558e8915171384987494bc17b00e27/cypress.tgz
+        working-directory: frontend
       - name: Cypress tests
         uses: cypress-io/github-action@v5.5.1
         with:


### PR DESCRIPTION
Workaround until Cypress publishes a release that fixes dynamic dependency imports.

Done according to this comment: https://github.com/cypress-io/cypress/issues/25913#issuecomment-1481802265