### PR TITLE
Use different job for fetching latest tag

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -21,10 +21,11 @@ jobs:
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       # fetch latest tag for SonarCloud
-      - uses: actions-ecosystem/action-get-latest-tag@v1
+      - uses: "WyriHaximus/github-action-get-previous-tag@v1.3.0"
         id: get-latest-tag
         with:
-          semver_only: true
+          fallback: 0.0.1
+          prefix: v
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -20,6 +20,11 @@ jobs:
       - uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+      # fetch latest tag for SonarCloud
+      - uses: actions-ecosystem/action-get-latest-tag@v1
+        id: get-latest-tag
+        with:
+          semver_only: true
       - uses: actions/setup-node@v3
         with:
           node-version: 18
@@ -37,6 +42,7 @@ jobs:
             # mandatory
             -Dsonar.projectKey=stnokott_r6-dissect-influx
             -Dsonar.organization=stnokott-github
+            -Dsonar.projectVersion=${{ steps.get-latest-tag.outputs.tag }}
             -Dsonar.typescript.tsconfigPaths=frontend/tsconfig.json
             -Dsonar.exclusions=frontend/public/**/*,frontend/wailsjs/**,frontend/cypress/support/**,**/*.cy.ts
             -Dsonar.test.inclusions=**/*.cy.ts


### PR DESCRIPTION
Previous job (`actions-ecosystem/action-get-latest-tag`) was using deprecated commands